### PR TITLE
Quote provider parameter for vendor publish

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ The service provider will automatically get registered. Or you may manually add 
 ```
 - Add configuration file `amqp.php` in your config directory with the following command.
 ```php
-php artisan vendor:publish --provider=Anik\Amqp\ServiceProviders\AmqpServiceProvider
+php artisan vendor:publish --provider="Anik\Amqp\ServiceProviders\AmqpServiceProvider"
 ```
 ### For Lumen
 - Add the service provider in your `bootstrap/app.php` file.


### PR DESCRIPTION
When using the command as is, Laravel returns the following message: `Unable to locate publishable resources.`

I believe this may be because my shell is resolving some of the `\` as escape characters.

Adding the quotes around the provider to pass it as a string resolved this issue for me.

Shell is `zsh` if that helps - maybe this isn't an issue on bash.