### PR TITLE
Improve false assertion

### DIFF
--- a/tests/Unit/Qos/QosTest.php
+++ b/tests/Unit/Qos/QosTest.php
@@ -23,7 +23,7 @@ class QosTest extends TestCase
         $qos = new Qos();
         $this->assertSame(0, $qos->getPrefetchSize());
         $this->assertSame(0, $qos->getPrefetchCount());
-        $this->assertSame(false, $qos->isGlobal());
+        $this->assertFalse($qos->isGlobal());
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertFalse` to assert expected is `false`.