### PR TITLE
Fix: AmqpConnectionConfigBuilder mappers

### DIFF
--- a/src/AmqpConnectionConfigBuilder.php
+++ b/src/AmqpConnectionConfigBuilder.php
@@ -10,7 +10,7 @@ class AmqpConnectionConfigBuilder implements ConfigBuilder
         'host' => 'setHost',
         'port' => 'setPort',
         'user' => 'setUser',
-        'password' => 'setUser',
+        'password' => 'setPassword',
         'vhost' => 'setVhost',
         'io' => 'setIoType',
         'secure' => 'setIsSecure',


### PR DESCRIPTION
Hello,

The error message is:

```
2023-03-07 12:07:23.361339+00:00 [erro] <0.9957.1375> AMQPLAIN login refused: user '<<redacted_password>>' - invalid credentials
```

which leads me to believe, that user/password got somehow switched -> and this fix really works :)